### PR TITLE
Fix Namespace for DateTime in CronJobResult constructor

### DIFF
--- a/Entity/CronJobResult.php
+++ b/Entity/CronJobResult.php
@@ -52,7 +52,7 @@ class CronJobResult
 
     public function __construct()
     {
-        $this->runAt = new DateTime();
+        $this->runAt = new \DateTime();
     }
     
     /**


### PR DESCRIPTION
Add missing "\" before DateTime in CronJobResult constructor
